### PR TITLE
docs(pt): replace 'vua' with 'vue' in multiple files

### DIFF
--- a/src/guide/built-ins/transition.md
+++ b/src/guide/built-ins/transition.md
@@ -465,7 +465,7 @@ Cá está uma demonstração usando a [biblioteca GreenSock](https://greensock.c
 
 ## Transições Reutilizáveis {#reusable-transitions}
 
-As transições podem ser reutilizadas através do sistema de componente da Vua. Para criar uma transição reutilizável, podemos criar um componente que envolve o componente `<Transition>` e passar o conteúdo da ranhura:
+As transições podem ser reutilizadas através do sistema de componente da Vue. Para criar uma transição reutilizável, podemos criar um componente que envolve o componente `<Transition>` e passar o conteúdo da ranhura:
 
 ```vue{5}
 <!-- MyTransition.vue -->

--- a/src/guide/essentials/class-and-style.md
+++ b/src/guide/essentials/class-and-style.md
@@ -327,7 +327,7 @@ Nós podemos vincular o `:style` a um arranjo de vários objetos de estilo. Este
 
 ### Prefixação Automática
 
-Quando utilizares uma propriedade de CSS que exija um [prefixo](https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix) no `:style`, a Vue adicionará automaticamente o prefixo apropriado. A Vua faz isto verificando no tempo de execução para ver quais propriedades de estilo são suportadas no atual navegador. Se o navegador não suportar uma propriedade em particular então várias variantes prefixadas serão testadas para tentar encontrar uma que é suportada.
+Quando utilizares uma propriedade de CSS que exija um [prefixo](https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix) no `:style`, a Vue adicionará automaticamente o prefixo apropriado. A Vue faz isto verificando no tempo de execução para ver quais propriedades de estilo são suportadas no atual navegador. Se o navegador não suportar uma propriedade em particular então várias variantes prefixadas serão testadas para tentar encontrar uma que é suportada.
 
 ### Vários Valores
 

--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -6,7 +6,7 @@ Os componentes permitem-te separar a Interface de Utilizador (UI, sigla em Ingl�
 
 <!-- https://www.figma.com/file/qa7WHDQRWuEZNRs7iZRZSI/components -->
 
-É muito semelhante a como encaixamos elementos nativos de HTML, mas a Vue implemente seu próprio modelo de componente que permite-nos resumir o conteúdo e lógica personalizados dentro de cada componente. A Vua também trabalha com Componentes de Web nativos, [leia mais a respeito](/guide/extras/web-components).
+É muito semelhante a como encaixamos elementos nativos de HTML, mas a Vue implemente seu próprio modelo de componente que permite-nos resumir o conteúdo e lógica personalizados dentro de cada componente. A Vue também trabalha com Componentes de Web nativos, [leia mais a respeito](/guide/extras/web-components).
 
 ## Definindo um Componente
 

--- a/src/guide/essentials/computed.md
+++ b/src/guide/essentials/computed.md
@@ -95,7 +95,7 @@ Cá temos declarado uma propriedade computada `publishedBooksMessage`.
 
 Tente mudar o valor do arranjo `books` no `data` da aplicação e verás como `publishedBooksMessage` está mudando por consequência.
 
-Tu podes vincular dados às propriedades computadas no modelo de marcação tal como uma propriedade normal. A Vua está consciente de que `this.publishedBooksMessage` depende de `this.author.books`, assim ela atualizará qualquer vínculos que dependem de `this.publishedBooksMessage` quando `this.author.books` mudar.
+Tu podes vincular dados às propriedades computadas no modelo de marcação tal como uma propriedade normal. A Vue está consciente de que `this.publishedBooksMessage` depende de `this.author.books`, assim ela atualizará qualquer vínculos que dependem de `this.publishedBooksMessage` quando `this.author.books` mudar.
 
 Consulte também: [Tipando Propriedades Computadas](/guide/typescript/options-api.html#typing-computed-properties) <sup class="vt-badge ts" />
 

--- a/src/guide/essentials/event-handling.md
+++ b/src/guide/essentials/event-handling.md
@@ -223,7 +223,7 @@ methods: {
 
 É muito comum precisar chamar `event.preventDefault()` ou `event.stopPropagation()` dentro de manipuladores de evento. Ainda que possamos fazer isto facilmente dentro de métodos, seria melhor se os métodos pudessem ser puramente a respeito da lógica dos dados em vez de ter que lidar com detalhes de evento de DOM.
 
-Para tratar este problema, a Vua fornece **modificadores de evento** para `v-on`. Recorda-te de que os modificadores são nomes especiais depois do nome do evento denotados por um ponto.
+Para tratar este problema, a Vue fornece **modificadores de evento** para `v-on`. Recorda-te de que os modificadores são nomes especiais depois do nome do evento denotados por um ponto.
 
 - `.stop`
 - `.prevent`
@@ -295,7 +295,7 @@ No exemplo acima, o manipulador só será chamado se `$event.key` for igual a `'
 
 ### Pseudónimos de Tecla {#key-aliases}
 
-A Vua fornece pseudónimos para as teclas mais comummente utilizadas:
+A Vue fornece pseudónimos para as teclas mais comummente utilizadas:
 
 - `.enter`
 - `.tab`

--- a/src/guide/essentials/list.md
+++ b/src/guide/essentials/list.md
@@ -319,7 +319,7 @@ Consulte [este exemplo de uma lista de afazeres simples](https://play.vuejs.org/
 
 ### Métodos de Mutação {#mutation-methods}
 
-A Vua é capaz de detetar quando métodos de mutação de um arranjo reativo são chamados e aciona as atualizações necessárias. Estes métodos de mutação são:
+A Vue é capaz de detetar quando métodos de mutação de um arranjo reativo são chamados e aciona as atualizações necessárias. Estes métodos de mutação são:
 
 - `push()`
 - `pop()`
@@ -349,7 +349,7 @@ this.items = this.items.filter((item) => item.message.match(/Foo/))
 
 </div>
 
-Tu podes achar que isto fará a Vue deixar fora o DOM existente e reinterpretar a lista inteira - felizmente, este não é o caso. A Vua implementa algumas heurísticas inteligentes para maximizar a reutilização do elemento do DOM, assim substituir um arranjo com um outro arranjo contendo objetos que se sobrepõem é uma operação muito eficiente.
+Tu podes achar que isto fará a Vue deixar fora o DOM existente e reinterpretar a lista inteira - felizmente, este não é o caso. A Vue implementa algumas heurísticas inteligentes para maximizar a reutilização do elemento do DOM, assim substituir um arranjo com um outro arranjo contendo objetos que se sobrepõem é uma operação muito eficiente.
 
 ## Exibindo Resultados Filtrados ou Organizados {#displaying-filtered-sorted-results}
 

--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -2,7 +2,7 @@
 
 A Vue utiliza uma sintaxe de modelo de marcação baseada na HTML que permite-te vincular de maneira declarativa o DOM interpretado aos dados da instância do componente subjacente. Todos modelos de marcação de Vue são HTML sintaticamente validos que podem ser analisados por navegadores e analisadores de HTML compatíveis a especificação.
 
-Nos bastidores, a Vua compila os modelos de marcação para um código de JavaScript altamente otimizado. Combinada com o sistema de reatividade, a Vue é capaz de compreender inteligentemente o número mínimo de componentes à reinterpretar e aplicar a quantidade mínima de manipulações do DOM quando o estado da aplicação mudar.
+Nos bastidores, a Vue compila os modelos de marcação para um código de JavaScript altamente otimizado. Combinada com o sistema de reatividade, a Vue é capaz de compreender inteligentemente o número mínimo de componentes à reinterpretar e aplicar a quantidade mínima de manipulações do DOM quando o estado da aplicação mudar.
 
 Se estiveres familiarizado com os conceitos do DOM Virtual e preferires o poder bruto da JavaScript, também podes [escrever diretamente funções de interpretação](/guide/extras/render-function) no lugar dos modelos de marcação, com suporte opcional ao JSX. No entanto, nota que eles não gozam do mesmo nível de otimizações de tempo de compilação como os modelos de marcação.
 
@@ -113,7 +113,7 @@ Tu podes vinculá-los a um único elemento utilizando `v-bind` sem um argumento:
 
 ## Utilizando Expressões de JavaScript {#using-javascript-expressions}
 
-Até aqui só temos estado vinculando a chaves de propriedade simples nos modelos de marcação. Mas a Vua atualmente suporta o poder completo das expressões de JavaScript dentro de todas vinculações de data:
+Até aqui só temos estado vinculando a chaves de propriedade simples nos modelos de marcação. Mas a Vue atualmente suporta o poder completo das expressões de JavaScript dentro de todas vinculações de data:
 
 ```vue-html
 {{ number + 1 }}

--- a/src/guide/introduction.md
+++ b/src/guide/introduction.md
@@ -26,7 +26,7 @@ footer: false
 
 ## O que a Vue é? {#what-is-vue}
 
-Vua (pronunciado /vjuː/, como **view** ) é uma abstração de JavaScript para construção de interfaces de utilizador. Ela constrói sobre a HTML, CSS e JavaScript padrão, e fornece um modelo de programação declarativa baseada em componente que ajuda-te a programar interfaces de utilizador eficientemente, sejam elas simples ou complexas.
+Vue (pronunciado /vjuː/, como **view** ) é uma abstração de JavaScript para construção de interfaces de utilizador. Ela constrói sobre a HTML, CSS e JavaScript padrão, e fornece um modelo de programação declarativa baseada em componente que ajuda-te a programar interfaces de utilizador eficientemente, sejam elas simples ou complexas.
 
 Cá está um exemplo mínimo:
 
@@ -77,7 +77,7 @@ O resto da documentação presume familiaridade fundamental com a HTML, CSS e Ja
 
 ## A Abstração Progressiva {#the-progressive-framework}
 
-A Vua é uma abstração e ecossistema que cobre a maioria das funcionalidades comuns necessárias no desenvolvimento de frontend. Porém a web é extremamente diversa - as coisas que construimos na web podem variar drasticamente na forma e escala. Com isto em mente, a Vue está desenhada para ser flexível e adotável incrementalmente. Dependendo do teu caso de uso, a Vue pode ser utilizada nas diferentes maneiras:
+A Vue é uma abstração e ecossistema que cobre a maioria das funcionalidades comuns necessárias no desenvolvimento de frontend. Porém a web é extremamente diversa - as coisas que construimos na web podem variar drasticamente na forma e escala. Com isto em mente, a Vue está desenhada para ser flexível e adotável incrementalmente. Dependendo do teu caso de uso, a Vue pode ser utilizada nas diferentes maneiras:
 
 - Otimizando o HTML estático sem uma etapa de construção
 - Embutindo como Componentes de Web em qualquer página
@@ -90,7 +90,7 @@ Se considerares estes conceitos intimidantes, não te preocupes! A aula e o guia
 
 Se fores um programador experiente interessado em como integrar melhor a Vue na tua pilha, ou estiveres curioso a respeito do que estes termos querem dizer, nós os discutimos com mais detalhes em [Maneiras de Utilização da Vue](/guide/extras/ways-of-using-vue).
 
-Apesar da flexibilidade, o conhecimento principal a respeito de como a Vua funciona é partilhado por todos estes casos de uso. Mesmo se agora fores apenas um principiante, o conhecimento adquirido pelo caminho manter-se-á útil a medida que cresceres para lidares com objetivos mais ambiciosos no futuro. Se fores um veterano, podes escolher a maneira ideal de entregar a Vue baseado nos problemas que estás tentando resolver, enquanto conservas a mesma produtividade. Isto é a razão de nós chamarmos a Vue de "A Abstração Progressiva": é uma abstração que pode crescer contigo e adaptar-se as tuas necessidades.
+Apesar da flexibilidade, o conhecimento principal a respeito de como a Vue funciona é partilhado por todos estes casos de uso. Mesmo se agora fores apenas um principiante, o conhecimento adquirido pelo caminho manter-se-á útil a medida que cresceres para lidares com objetivos mais ambiciosos no futuro. Se fores um veterano, podes escolher a maneira ideal de entregar a Vue baseado nos problemas que estás tentando resolver, enquanto conservas a mesma produtividade. Isto é a razão de nós chamarmos a Vue de "A Abstração Progressiva": é uma abstração que pode crescer contigo e adaptar-se as tuas necessidades.
 
 ## Componentes de Ficheiro Único {#single-file-components}
 

--- a/src/guide/reusability/composables.md
+++ b/src/guide/reusability/composables.md
@@ -86,7 +86,7 @@ const { x, y } = useMouse()
   Mouse position is at: {{ x }}, {{ y }}
 </div>
 
-[Experimente-o na Zona de Testes](https://play.vuejs.org/#eNqNkj1rwzAQhv/KocUOGKVzSAIdurVjoQUvJj4XlfgkJNmxMfrvPcmJkkKHLrbu69H7SlrEszFyHFDsxN6drDIeHPrBHGtSvdHWwwKDwzfNHwjQWd1DIbd9jOW3K2qq6aTJxb6pgpl7Dnmg3NS0365YBnLgsTfnxiNHACvUaKe80gTKQeN3sDAIQqjignEhIvKYqMRta1acFVrsKtDEQPLYxuU7cV8Msmg2mdTilIa6gU5p27tYWKKq1c3ENphaPrGFW25+yMXsHWFaFlfiiOSvFIBJjs15QJ5JeWmaL/xYS/Mfpc9YYrPxl52ULOpwhIuiVl9k07Yvsf9VOY+EtizSWfR6xKK6itgkvQ/+fyNs6v4XJXIsPwVL+WprCiL8AEUxw5s=)
+[Experimente-o na Zona de Testes](https://play.vuejs.org/#eNqNkj1rwzAQhv/KocUOGKVzSAIdurVjoQUvJj4XlfgkJNmxMfrvPcmJkkKHLrbu69H7SlrEszFyHFDsxN6drDIeHPrBHGtSvdHWwwKDwzfNHwjQWd1DIbd9jOW3K2qq6aTJxb6pgpl7Dnmg3NS0365YBnLgsTfnxiNHACVueKe80gTKQeN3sDAIQqjignEhIvKYqMRta1acFVrsKtDEQPLYxuU7cV8Msmg2mdTilIa6gU5p27tYWKKq1c3ENphaPrGFW25+yMXsHWFaFlfiiOSvFIBJjs15QJ5JeWmaL/xYS/Mfpc9YYrPxl52ULOpwhIuiVl9k07Yvsf9VOY+EtizSWfR6xKK6itgkvQ/+fyNs6v4XJXIsPwVL+WprCiL8AEUxw5s=)
 
 Conforme podemos ver, a lógica fundamental permanece idêntica - tudo o que tivemos que fazer foi movê-la para uma função externa e retornar o estado que deveria ser exposto. Tal como dentro de um componente, podes utilizar uma grama completa de [funções de API de Composição](/api/#composition-api) nas funções de composição. A mesma funcionalidade de `useMouse()` pode agora ser utilizada em qualquer componente.
 

--- a/src/tutorial/src/step-2/description.md
+++ b/src/tutorial/src/step-2/description.md
@@ -72,7 +72,7 @@ Repare como não precisamos utilizar `.value` quando estamos acessando a referê
 
 <div class="options-api">
 
-Os estados que quando mudados podem acionar atualizações são considerados **reativos**. Na Vua, o estado reativo é segurado nos componentes. No exemplo de código, o objeto que está sendo passado para `createApp()` é um componente.
+Os estados que quando mudados podem acionar atualizações são considerados **reativos**. Na Vue, o estado reativo é segurado nos componentes. No exemplo de código, o objeto que está sendo passado para `createApp()` é um componente.
 
 Nós podemos declarar estado reativo utilizando a opção de componente `data`, que deve ser uma função que retorna um objeto:
 

--- a/src/tutorial/src/step-3/description.md
+++ b/src/tutorial/src/step-3/description.md
@@ -1,6 +1,6 @@
 # Vinculação de Atributo
 
-Na Vua, os bigodes são utilizados apenas para interpolação de texto. Para vincular um atributo à um valor dinâmico, utilizamos a diretiva `v-bind`:
+Na Vue, os bigodes são utilizados apenas para interpolação de texto. Para vincular um atributo à um valor dinâmico, utilizamos a diretiva `v-bind`:
 
 ```vue-html
 <div v-bind:id="dynamicId"></div>

--- a/src/tutorial/src/step-5/description.md
+++ b/src/tutorial/src/step-5/description.md
@@ -34,7 +34,7 @@ function onInput(e) {
 
 Experimente digitar na caixa de entrada - deves ver o texto em `<p>` atualizando a medida que digitas.
 
-Para simplificar vínculos de duas vias, a Vua fornece uma diretiva, `v-model`, que é essencialmente um açúcar de sintaxe para o que está acima:
+Para simplificar vínculos de duas vias, a Vue fornece uma diretiva, `v-model`, que é essencialmente um açúcar de sintaxe para o que está acima:
 
 ```vue-html
 <input v-model="text">


### PR DESCRIPTION
## Description of Problem
Several "Vua" instances found while reading the documentation

## Proposed Solution
Replace "Vua" with "Vue"

